### PR TITLE
 # EDIT - Byte builder function add

### DIFF
--- a/src/bytes_builder.hpp
+++ b/src/bytes_builder.hpp
@@ -40,13 +40,8 @@ public:
     }
   }
 
-  void appendDec(uint64_t dec) {
-    for (int i = sizeof(dec) - 1; i >= 0; i--) {
-      bytes.push_back((dec >> (8 * i)) & 0xFF);
-    }
-  }
-
-  void appendDec(int dec) {
+  template <typename T, typename = enable_if_t<is_same<T, int>::value || is_same<T, uint64_t>::value>>
+  void appendDec(T &dec) {
     for (int i = sizeof(dec) - 1; i >= 0; i--) {
       bytes.push_back((dec >> (8 * i)) & 0xFF);
     }

--- a/src/bytes_builder.hpp
+++ b/src/bytes_builder.hpp
@@ -40,6 +40,18 @@ public:
     }
   }
 
+  void appendDec(uint64_t dec) {
+    for (int i = sizeof(dec) - 1; i >= 0; i--) {
+      bytes.push_back((dec >> (8 * i)) & 0xFF);
+    }
+  }
+
+  void appendDec(int dec) {
+    for (int i = sizeof(dec) - 1; i >= 0; i--) {
+      bytes.push_back((dec >> (8 * i)) & 0xFF);
+    }
+  }
+
   template <unsigned int S>
   void appendBase(string_view baseXX_str) {
     auto decoded_data = TypeConverter::decodeBase<S>(baseXX_str);

--- a/test/bytes_builder.cpp
+++ b/test/bytes_builder.cpp
@@ -9,7 +9,9 @@ TEST_CASE("BytesBuilder") {
     string test_b64_str = "YmFzZTY0dGVzdA=="; // 10-bytes "base64test"
     string test_b58_str = "6XaWvmhVhb7vJP";   // 10-bytes "base58test"
     string test_hex_str = "61626364";         // 4-bytes
-    string test_dec_str = "1234";             // 4-bytes
+    string test_dec_str = "1234";             // 8-bytes
+    uint64_t test_dec_uint64 = 1234;          // 8-bytes
+    int test_dec_int = 5678;                  // 4-bytes
 
     string actual_str = test_normal_str + "base64test" + "base58test";
 
@@ -23,12 +25,24 @@ TEST_CASE("BytesBuilder") {
       actual_str.push_back((dec >> (i * 8)) & 0xFF);
     }
 
+    uint64_t uint64_dec = test_dec_uint64;
+    for (int i = 7; i >= 0; i--) {
+      actual_str.push_back((uint64_dec >> (i * 8)) & 0xFF);
+    }
+
+    int int_dec = test_dec_int;
+    for (int i = 3; i >= 0; i--) {
+      actual_str.push_back((test_dec_int >> (i * 8)) & 0xFF);
+    }
+
     BytesBuilder bytes_builder;
     bytes_builder.append(test_normal_str);
     bytes_builder.appendBase<64>(test_b64_str);
     bytes_builder.appendBase<58>(test_b58_str);
     bytes_builder.appendHex(test_hex_str);
     bytes_builder.appendDec(test_dec_str);
+    bytes_builder.appendDec(test_dec_uint64);
+    bytes_builder.appendDec(test_dec_int);
 
     REQUIRE(bytes_builder.getBytes().size() == actual_str.length());
     REQUIRE(bytes_builder.getString() == actual_str);


### PR DESCRIPTION
byte builder로 서명 생성 등을 할 때, input으로 숫자 형식이 들어오더라도
바로 처리할 수 있도록 오버로딩 함수를 추가하였습니다.
time 등을 처리하는 uint64_t 형태와 block height 등을 처리하는 int 형태를
모두 처리하기 위함입니다.