### PR TITLE
 # EDIT - private member fucntion -> public one

### DIFF
--- a/src/ags.hpp
+++ b/src/ags.hpp
@@ -1,16 +1,16 @@
 #ifndef GRUUT_UTILS_AGS_HPP
 #define GRUUT_UTILS_AGS_HPP
 
+#include <algorithm>
 #include <string>
 #include <string_view>
 #include <vector>
-#include <algorithm>
 
-#include <botan-2/botan/bigint.h>
-#include <botan-2/botan/point_gfp.h>
-#include <botan-2/botan/auto_rng.h>
-#include <botan-2/botan/ec_group.h>
 #include "type_converter.hpp"
+#include <botan-2/botan/auto_rng.h>
+#include <botan-2/botan/bigint.h>
+#include <botan-2/botan/ec_group.h>
+#include <botan-2/botan/point_gfp.h>
 
 using namespace std;
 
@@ -20,17 +20,17 @@ struct Signature {
 
   string toString() {
     auto d_hex = d.to_hex_string();
-    if(d_hex.length() < 64) {
+    if (d_hex.length() < 64) {
       auto padding_size = 64 - d_hex.length();
-      for(auto i=0; i < padding_size; ++i) {
+      for (auto i = 0; i < padding_size; ++i) {
         d_hex = "0" + d_hex;
       }
     }
 
     auto z_hex = z.to_hex_string();
-    if(z_hex.length() < 64) {
+    if (z_hex.length() < 64) {
       auto padding_size = 64 - z_hex.length();
-      for(auto i=0; i < padding_size; ++i) {
+      for (auto i = 0; i < padding_size; ++i) {
         z_hex = "0" + z_hex;
       }
     }
@@ -67,6 +67,9 @@ public:
   bool aggregateVerify(vector<AggregateSig> &agg_set, Botan::BigInt &sum_of_z);
 
   Signature sigStrToSignature(const string &sig);
+
+  Botan::PointGFp getPublicKeyFromPem(const string &pk_pem);
+
 private:
   Botan::AutoSeeded_RNG rng;
   Botan::EC_Group group_domain;
@@ -81,7 +84,6 @@ private:
 
   Botan::BigInt getPrivateKey(const string &sk_pem, const string &pass = "");
   Botan::PointGFp getPublicKey(const string &encoded_pk);
-  Botan::PointGFp getPublicKeyFromPem(const string &pk_pem);
 
   bool isUniqueElements(vector<AggregateSig> &aggregate_set);
 };

--- a/src/ecdsa.hpp
+++ b/src/ecdsa.hpp
@@ -77,6 +77,12 @@ public:
     }
   }
 
+  static bool doVerify(Botan::Public_Key &ecdsa_public_key, const vector<uint8_t> &msg_bytes, const vector<uint8_t> &signature) {
+    Botan::PK_Verifier verifier(ecdsa_public_key, EMSA, Botan::Signature_Format::DER_SEQUENCE);
+
+    return verifier.verify_message(msg_bytes, signature);
+  }
+
 private:
   static Botan::ECDSA_PrivateKey getPrivateKey(string_view ecdsa_secret_key_pem, string_view passphrase = ""sv) {
     try {
@@ -96,12 +102,6 @@ private:
     Botan::PK_Signer signer(ecdsa_secret_key, auto_rng, EMSA, Botan::Signature_Format::DER_SEQUENCE);
 
     return signer.sign_message(msg_bytes, auto_rng);
-  }
-
-  static bool doVerify(Botan::Public_Key &ecdsa_public_key, const vector<uint8_t> &msg_bytes, const vector<uint8_t> &signature) {
-    Botan::PK_Verifier verifier(ecdsa_public_key, EMSA, Botan::Signature_Format::DER_SEQUENCE);
-
-    return verifier.verify_message(msg_bytes, signature);
   }
 
   static void onError(Botan::Exception &exception) {


### PR DESCRIPTION
- AGS::getPublickeyFromPem  public으로 이동
   * `Pem`에서 pub key를 뽑아내 사용해야하는 경우 발생

- ECDSA::doVerify(Public_key & ....) public으로 이동
   * Public_key를 직접받아서 검증해야하는 경우 발생

- Clang - format 적용